### PR TITLE
Render image attachments in statuses.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -7,6 +7,10 @@ body {
   clear: both;
 }
 
+.nsfw {
+  background: #493438;
+}
+
 .reblog > p:first-of-type {
   color: #999;
 }
@@ -65,11 +69,36 @@ body {
   position: relative;
 }
 
+.attachment-entry {
+  margin-top: 5px;
+}
+
+.attachment-entry input {
+  display: none;
+}
+
+.attachment-entry label {
+  display: block;
+  background: #111;
+  opacity: .95;
+  font-weight: normal;
+  font-size: 95%;
+  height: 10vh;
+  margin-bottom: -10vh;
+  text-align: center;
+  padding-top: 2rem;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.attachment-entry input:checked + label {
+  display: none;
+}
+
 .attachment-image {
    display: block;
    width: 100%;
    height: 10vh;
-   margin-top: 5px;
    text-decoration: none;
    cursor: zoom-in;
    border-radius: 2px;

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,7 @@
+body {
+  font-family: Roboto, sans-serif;
+}
+
 .status {
   min-height: 75px;
   clear: both;
@@ -47,6 +51,28 @@
 
 .status-text a, .u-url, .mention, .hashtag, .tag {
   color: #9baec8;
+}
+
+/* Attachments */
+
+.attachments {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  overflow: hidden;
+  width: 100%;
+  box-sizing: border-box;
+  position: relative;
+  max-height: 110px;
+}
+
+.attachment-image {
+   display: block;
+   width: 100%;
+   height: 110px;
+   text-decoration: none;
+   cursor: zoom-in;
+   border-radius: 2px;
 }
 
 /* Spoiler */

--- a/public/style.css
+++ b/public/style.css
@@ -63,13 +63,13 @@ body {
   width: 100%;
   box-sizing: border-box;
   position: relative;
-  max-height: 110px;
 }
 
 .attachment-image {
    display: block;
    width: 100%;
-   height: 110px;
+   height: 10vh;
+   margin-top: 5px;
    text-decoration: none;
    cursor: zoom-in;
    border-radius: 2px;

--- a/src/View.elm
+++ b/src/View.elm
@@ -56,11 +56,41 @@ icon name =
     i [ class <| "glyphicon glyphicon-" ++ name ] []
 
 
+attachmentPreview : Mastodon.Attachment -> Html Msg
+attachmentPreview { url, preview_url } =
+    li []
+        [ a
+            [ class "attachment-image"
+            , href url
+            , target "_blank"
+            , style
+                [ ( "background"
+                  , "url(" ++ preview_url ++ ") center center / cover no-repeat"
+                  )
+                ]
+            ]
+            []
+        ]
+
+
+attachmentListView : List Mastodon.Attachment -> Html Msg
+attachmentListView attachments =
+    case attachments of
+        [] ->
+            text ""
+
+        attachments ->
+            ul [ class "attachments" ] <| List.map attachmentPreview attachments
+
+
 statusContentView : Mastodon.Status -> Html Msg
 statusContentView status =
     case status.spoiler_text of
         "" ->
-            div [ class "status-text" ] <| formatContent status.content
+            div [ class "status-text" ]
+                [ div [] <| formatContent status.content
+                , attachmentListView status.media_attachments
+                ]
 
         spoiler ->
             -- Note: Spoilers are dealt with using pure CSS.
@@ -72,12 +102,15 @@ statusContentView status =
                     [ div [ class "spoiler" ] <| formatContent status.spoiler_text
                     , input [ type_ "checkbox", id statusId, class "spoiler-toggler" ] []
                     , label [ for statusId ] [ text "Reveal content" ]
-                    , div [ class "spoiled-content" ] <| formatContent status.content
+                    , div [ class "spoiled-content" ]
+                        [ div [] <| formatContent status.content
+                        , attachmentListView status.media_attachments
+                        ]
                     ]
 
 
 statusView : Mastodon.Status -> Html Msg
-statusView ({ account, content, reblog } as status) =
+statusView ({ account, media_attachments, content, reblog } as status) =
     case reblog of
         Just (Mastodon.Reblog reblog) ->
             div [ class "reblog" ]


### PR DESCRIPTION
Refs #15.

![screenshot at 18 08 06](https://cloud.githubusercontent.com/assets/41547/25286650/cba23a2a-26be-11e7-9441-cef815f53632.png)

Handles spoilers:

![screenshot at 18 16 36](https://cloud.githubusercontent.com/assets/41547/25286660/d0d6f512-26be-11e7-94ec-0047596b3de3.png)

Still need to find a way to hide images tagged as nsfw by default.
