### PR TITLE
Use project url instead of instance url

### DIFF
--- a/src/Model.elm
+++ b/src/Model.elm
@@ -152,7 +152,7 @@ registerApp { server, location } =
             "tooty"
             appUrl
             "read write follow"
-            appUrl
+            "https://github.com/n1k0/tooty"
             |> Mastodon.send AppRegistered
 
 


### PR DESCRIPTION
Instead of using the instance url which runs tooty (which will mostly be `http://localhost:8000`) use the project url.

So users will be able to know that we are using the most accomplished and stunning client ever build for Mastodon and will then join the amazing tooty community. :ok_woman: 