### PR TITLE
Added ellipsis for looong hashtags

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -231,7 +231,7 @@ body {
   word-wrap: break-word;
 }
 
-.ellipsis {
+.ellipsis, .hashtag {
   display: block;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
Not sure if it's OK to do like that. 
Issue #19. 

Before: 

![capture d ecran 2017-04-25 a 11 29 43](https://cloud.githubusercontent.com/assets/121870/25378553/b35c3f44-29aa-11e7-846a-5e830c9bd095.png)


After : 

![capture d ecran 2017-04-25 a 11 29 31](https://cloud.githubusercontent.com/assets/121870/25378563/ba32af92-29aa-11e7-9365-7a5411b7c3d3.png)
