### PR TITLE
Fix #49: Denote account relationships, follow & unfollow actions.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -335,8 +335,10 @@ body {
 
 /* Account rules */
 .account-detail {
-  text-align:center;
+  position: relative;
+  text-align: center;
 }
+
 .account-detail .opacity-layer{
   background: rgba(49,53,67,0.9);
 }
@@ -348,6 +350,14 @@ body {
   margin:0 auto 0;
 }
 
+.account-detail .btn {
+  position: absolute;
+  top: 1em;
+  left: 1em;
+  width: 50px;
+  height: 50px;
+  opacity: .8;
+}
 
 .account-detail .account-display-name {
   display: block;

--- a/public/style.css
+++ b/public/style.css
@@ -100,19 +100,37 @@ body {
 }
 
 .follow-entry {
-  min-height: 38px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-content: stretch;
+  align-items: flex-start;
 }
 
 .follow-entry .avatar {
+  order: 0;
+  flex: 0 1 auto;
+  align-self: auto;
   width: 38px;
   height: 38px;
+  margin-right: 10px;
 }
-.follow-entry .username {
-  font-weight: normal;
-  font-size: 97%;
-  margin-left: 50px;
+
+.follow-entry .userinfo {
+  order: 0;
+  flex: 10 1 auto;
+  align-self: auto;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.follow-entry button {
+  order: 0;
+  flex: 0 1 auto;
+  align-self: auto;
+  width: 40px;
+  height: 40px;
 }
 
 .acct {

--- a/src/Command.elm
+++ b/src/Command.elm
@@ -8,7 +8,10 @@ module Command
         , loadNotifications
         , loadUserAccount
         , loadAccount
-        , loadAccountInfo
+        , loadAccountTimeline
+        , loadAccountFollowers
+        , loadAccountFollowing
+        , loadRelationships
         , loadThread
         , loadTimelines
         , postStatus
@@ -119,18 +122,45 @@ loadAccount client accountId =
             Cmd.none
 
 
-loadAccountInfo : Maybe Client -> Int -> Cmd Msg
-loadAccountInfo client accountId =
+loadAccountTimeline : Maybe Client -> Int -> Cmd Msg
+loadAccountTimeline client accountId =
     case client of
         Just client ->
-            Cmd.batch
-                [ Mastodon.Http.fetchAccountTimeline client accountId
-                    |> Mastodon.Http.send (MastodonEvent << AccountTimeline)
-                , Mastodon.Http.fetchAccountFollowers client accountId
-                    |> Mastodon.Http.send (MastodonEvent << AccountFollowers)
-                , Mastodon.Http.fetchAccountFollowing client accountId
-                    |> Mastodon.Http.send (MastodonEvent << AccountFollowing)
-                ]
+            Mastodon.Http.fetchAccountTimeline client accountId
+                |> Mastodon.Http.send (MastodonEvent << AccountTimeline)
+
+        Nothing ->
+            Cmd.none
+
+
+loadAccountFollowers : Maybe Client -> Int -> Cmd Msg
+loadAccountFollowers client accountId =
+    case client of
+        Just client ->
+            Mastodon.Http.fetchAccountFollowers client accountId
+                |> Mastodon.Http.send (MastodonEvent << AccountFollowers)
+
+        Nothing ->
+            Cmd.none
+
+
+loadAccountFollowing : Maybe Client -> Int -> Cmd Msg
+loadAccountFollowing client accountId =
+    case client of
+        Just client ->
+            Mastodon.Http.fetchAccountFollowing client accountId
+                |> Mastodon.Http.send (MastodonEvent << AccountFollowing)
+
+        Nothing ->
+            Cmd.none
+
+
+loadRelationships : Maybe Client -> List Int -> Cmd Msg
+loadRelationships client accountIds =
+    case client of
+        Just client ->
+            Mastodon.Http.fetchRelationships client accountIds
+                |> Mastodon.Http.send (MastodonEvent << AccountRelationships)
 
         Nothing ->
             Cmd.none

--- a/src/Command.elm
+++ b/src/Command.elm
@@ -20,6 +20,8 @@ module Command
         , unreblogStatus
         , favouriteStatus
         , unfavouriteStatus
+        , follow
+        , unfollow
         )
 
 import Json.Encode as Encode
@@ -256,6 +258,28 @@ unfavouriteStatus client statusId =
         Just client ->
             Mastodon.Http.unfavourite client statusId
                 |> Mastodon.Http.send (MastodonEvent << FavoriteRemoved)
+
+        Nothing ->
+            Cmd.none
+
+
+follow : Maybe Client -> Int -> Cmd Msg
+follow client id =
+    case client of
+        Just client ->
+            Mastodon.Http.follow client id
+                |> Mastodon.Http.send (MastodonEvent << AccountFollowed)
+
+        Nothing ->
+            Cmd.none
+
+
+unfollow : Maybe Client -> Int -> Cmd Msg
+unfollow client id =
+    case client of
+        Just client ->
+            Mastodon.Http.unfollow client id
+                |> Mastodon.Http.send (MastodonEvent << AccountUnfollowed)
 
         Nothing ->
             Cmd.none

--- a/src/Command.elm
+++ b/src/Command.elm
@@ -117,8 +117,12 @@ loadAccount : Maybe Client -> Int -> Cmd Msg
 loadAccount client accountId =
     case client of
         Just client ->
-            Mastodon.Http.fetchAccount client accountId
-                |> Mastodon.Http.send (MastodonEvent << AccountReceived)
+            Cmd.batch
+                [ Mastodon.Http.fetchAccount client accountId
+                    |> Mastodon.Http.send (MastodonEvent << AccountReceived)
+                , Mastodon.Http.fetchRelationships client [ accountId ]
+                    |> Mastodon.Http.send (MastodonEvent << AccountRelationship)
+                ]
 
         Nothing ->
             Cmd.none

--- a/src/Mastodon/ApiUrl.elm
+++ b/src/Mastodon/ApiUrl.elm
@@ -19,6 +19,8 @@ module Mastodon.ApiUrl
         , unreblog
         , favourite
         , unfavourite
+        , follow
+        , unfollow
         , streaming
         )
 
@@ -50,6 +52,16 @@ accounts =
 account : Int -> String
 account id =
     accounts ++ (toString id)
+
+
+follow : Server -> Int -> String
+follow server id =
+    server ++ accounts ++ (toString id) ++ "/follow"
+
+
+unfollow : Server -> Int -> String
+unfollow server id =
+    server ++ accounts ++ (toString id) ++ "/unfollow"
 
 
 userAccount : Server -> String

--- a/src/Mastodon/ApiUrl.elm
+++ b/src/Mastodon/ApiUrl.elm
@@ -12,6 +12,7 @@ module Mastodon.ApiUrl
         , homeTimeline
         , publicTimeline
         , notifications
+        , relationships
         , statuses
         , context
         , reblog
@@ -54,6 +55,17 @@ account id =
 userAccount : Server -> String
 userAccount server =
     server ++ accounts ++ "verify_credentials"
+
+
+relationships : List Int -> String
+relationships ids =
+    let
+        qs =
+            ids
+                |> List.map (\id -> "id[]=" ++ (toString id))
+                |> String.join "&"
+    in
+        accounts ++ "relationships?" ++ qs
 
 
 followers : Int -> String

--- a/src/Mastodon/Decoder.elm
+++ b/src/Mastodon/Decoder.elm
@@ -11,6 +11,7 @@ module Mastodon.Decoder
         , notificationDecoder
         , tagDecoder
         , reblogDecoder
+        , relationshipDecoder
         , statusDecoder
         , webSocketPayloadDecoder
         , webSocketEventDecoder
@@ -98,6 +99,17 @@ notificationDecoder =
         |> Pipe.required "created_at" Decode.string
         |> Pipe.required "account" accountDecoder
         |> Pipe.optional "status" (Decode.nullable statusDecoder) Nothing
+
+
+relationshipDecoder : Decode.Decoder Relationship
+relationshipDecoder =
+    Pipe.decode Relationship
+        |> Pipe.required "id" Decode.int
+        |> Pipe.required "blocking" Decode.bool
+        |> Pipe.required "followed_by" Decode.bool
+        |> Pipe.required "following" Decode.bool
+        |> Pipe.required "muting" Decode.bool
+        |> Pipe.required "requested" Decode.bool
 
 
 tagDecoder : Decode.Decoder Tag

--- a/src/Mastodon/Http.elm
+++ b/src/Mastodon/Http.elm
@@ -17,6 +17,7 @@ module Mastodon.Http
         , fetchNotifications
         , fetchGlobalTimeline
         , fetchUserTimeline
+        , fetchRelationships
         , postStatus
         , deleteStatus
         , userAccount
@@ -114,6 +115,11 @@ fetchAccount client accountId =
 fetchUserTimeline : Client -> Request (List Status)
 fetchUserTimeline client =
     fetch client ApiUrl.homeTimeline <| Decode.list statusDecoder
+
+
+fetchRelationships : Client -> List Int -> Request (List Relationship)
+fetchRelationships client ids =
+    fetch client (ApiUrl.relationships ids) <| Decode.list relationshipDecoder
 
 
 fetchLocalTimeline : Client -> Request (List Status)

--- a/src/Mastodon/Http.elm
+++ b/src/Mastodon/Http.elm
@@ -6,6 +6,8 @@ module Mastodon.Http
         , unreblog
         , favourite
         , unfavourite
+        , follow
+        , unfollow
         , register
         , getAuthorizationUrl
         , getAccessToken
@@ -207,3 +209,17 @@ unfavourite client id =
     HttpBuilder.post (ApiUrl.unfavourite client.server id)
         |> HttpBuilder.withHeader "Authorization" ("Bearer " ++ client.token)
         |> HttpBuilder.withExpect (Http.expectJson statusDecoder)
+
+
+follow : Client -> Int -> Request Account
+follow client id =
+    HttpBuilder.post (ApiUrl.follow client.server id)
+        |> HttpBuilder.withHeader "Authorization" ("Bearer " ++ client.token)
+        |> HttpBuilder.withExpect (Http.expectJson accountDecoder)
+
+
+unfollow : Client -> Int -> Request Account
+unfollow client id =
+    HttpBuilder.post (ApiUrl.unfollow client.server id)
+        |> HttpBuilder.withHeader "Authorization" ("Bearer " ++ client.token)
+        |> HttpBuilder.withExpect (Http.expectJson accountDecoder)

--- a/src/Mastodon/Http.elm
+++ b/src/Mastodon/Http.elm
@@ -211,15 +211,15 @@ unfavourite client id =
         |> HttpBuilder.withExpect (Http.expectJson statusDecoder)
 
 
-follow : Client -> Int -> Request Account
+follow : Client -> Int -> Request Relationship
 follow client id =
     HttpBuilder.post (ApiUrl.follow client.server id)
         |> HttpBuilder.withHeader "Authorization" ("Bearer " ++ client.token)
-        |> HttpBuilder.withExpect (Http.expectJson accountDecoder)
+        |> HttpBuilder.withExpect (Http.expectJson relationshipDecoder)
 
 
-unfollow : Client -> Int -> Request Account
+unfollow : Client -> Int -> Request Relationship
 unfollow client id =
     HttpBuilder.post (ApiUrl.unfollow client.server id)
         |> HttpBuilder.withHeader "Authorization" ("Bearer " ++ client.token)
-        |> HttpBuilder.withExpect (Http.expectJson accountDecoder)
+        |> HttpBuilder.withExpect (Http.expectJson relationshipDecoder)

--- a/src/Mastodon/Model.elm
+++ b/src/Mastodon/Model.elm
@@ -11,6 +11,7 @@ module Mastodon.Model
         , Notification
         , NotificationAggregate
         , Reblog(..)
+        , Relationship
         , Tag
         , Status
         , StatusRequestBody
@@ -146,6 +147,16 @@ type alias NotificationAggregate =
 
 type Reblog
     = Reblog Status
+
+
+type alias Relationship =
+    { id : Int
+    , blocking : Bool
+    , followed_by : Bool
+    , following : Bool
+    , muting : Bool
+    , requested : Bool
+    }
 
 
 type alias Status =

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -152,6 +152,9 @@ deleteStatusFromTimeline statusId timeline =
             )
 
 
+{-| Update viewed account relationships as well as the relationship with the
+current connected user, both according to the "following" status provided.
+-}
 processFollowEvent : Relationship -> Bool -> Model -> Model
 processFollowEvent relationship flag model =
     let
@@ -166,8 +169,11 @@ processFollowEvent relationship flag model =
 
         accountRelationship =
             case model.accountRelationship of
-                Just relationship ->
-                    Just { relationship | following = flag }
+                Just accountRelationship ->
+                    if accountRelationship.id == relationship.id then
+                        Just { relationship | following = flag }
+                    else
+                        model.accountRelationship
 
                 Nothing ->
                     Nothing

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -155,28 +155,27 @@ deleteStatusFromTimeline statusId timeline =
 processFollowEvent : Relationship -> Bool -> Model -> Model
 processFollowEvent relationship flag model =
     let
-        toggle entries =
-            { model
-                | accountRelationships =
-                    model.accountRelationships
-                        |> List.map
-                            (\r ->
-                                if r.id == relationship.id then
-                                    { r | following = flag }
-                                else
-                                    r
-                            )
-            }
+        updateRelationship r =
+            if r.id == relationship.id then
+                { r | following = flag }
+            else
+                r
+
+        accountRelationships =
+            model.accountRelationships |> List.map updateRelationship
+
+        accountRelationship =
+            case model.accountRelationship of
+                Just relationship ->
+                    Just { relationship | following = flag }
+
+                Nothing ->
+                    Nothing
     in
-        case model.currentView of
-            AccountFollowersView account followers ->
-                toggle followers
-
-            AccountFollowingView account following ->
-                toggle following
-
-            _ ->
-                model
+        { model
+            | accountRelationships = accountRelationships
+            , accountRelationship = accountRelationship
+        }
 
 
 updateDraft : DraftMsg -> Account -> Draft -> ( Draft, Cmd Msg )

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -151,6 +151,11 @@ deleteStatusFromTimeline statusId timeline =
             )
 
 
+processFollowEvent : Account -> Bool -> Model -> Model
+processFollowEvent account flag model =
+    model
+
+
 updateDraft : DraftMsg -> Account -> Draft -> ( Draft, Cmd Msg )
 updateDraft draftMsg currentUser draft =
     case draftMsg of
@@ -225,16 +230,16 @@ processMastodonEvent msg model =
 
         AccountFollowed result ->
             case result of
-                Ok _ ->
-                    model ! []
+                Ok account ->
+                    processFollowEvent account True model ! []
 
                 Err error ->
                     { model | errors = (errorText error) :: model.errors } ! []
 
         AccountUnfollowed result ->
             case result of
-                Ok _ ->
-                    model ! []
+                Ok account ->
+                    processFollowEvent account False model ! []
 
                 Err error ->
                     { model | errors = (errorText error) :: model.errors } ! []

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -54,6 +54,7 @@ init flags location =
         , accountFollowers = []
         , accountFollowing = []
         , accountRelationships = []
+        , accountRelationship = Nothing
         , notifications = []
         , draft = defaultDraft
         , errors = []
@@ -408,6 +409,17 @@ processMastodonEvent msg model =
                 Err error ->
                     { model | errors = (errorText error) :: model.errors } ! []
 
+        AccountRelationship result ->
+            case result of
+                Ok [ relationship ] ->
+                    { model | accountRelationship = Just relationship } ! []
+
+                Ok _ ->
+                    model ! []
+
+                Err error ->
+                    { model | errors = (errorText error) :: model.errors } ! []
+
         AccountRelationships result ->
             case result of
                 Ok relationships ->
@@ -596,6 +608,7 @@ update msg model =
                 , accountFollowers = []
                 , accountFollowing = []
                 , accountRelationships = []
+                , accountRelationship = Nothing
             }
                 ! [ Command.loadAccount model.client accountId ]
 

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -223,6 +223,22 @@ processMastodonEvent msg model =
                 Err error ->
                     { model | errors = (errorText error) :: model.errors } ! []
 
+        AccountFollowed result ->
+            case result of
+                Ok _ ->
+                    model ! []
+
+                Err error ->
+                    { model | errors = (errorText error) :: model.errors } ! []
+
+        AccountUnfollowed result ->
+            case result of
+                Ok _ ->
+                    model ! []
+
+                Err error ->
+                    { model | errors = (errorText error) :: model.errors } ! []
+
         AppRegistered result ->
             case result of
                 Ok registration ->

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -27,13 +27,13 @@ type ViewerMsg
 
 type MastodonMsg
     = AccessToken (Result Error AccessTokenResult)
-    | AccountFollowed (Result Error Account)
+    | AccountFollowed (Result Error Relationship)
     | AccountFollowers (Result Error (List Account))
     | AccountFollowing (Result Error (List Account))
     | AccountReceived (Result Error Account)
     | AccountRelationships (Result Error (List Relationship))
     | AccountTimeline (Result Error (List Status))
-    | AccountUnfollowed (Result Error Account)
+    | AccountUnfollowed (Result Error Relationship)
     | AppRegistered (Result Error AppRegistration)
     | ContextLoaded Status (Result Error Context)
     | CurrentUser (Result Error Account)
@@ -61,6 +61,7 @@ type Msg
     | CloseThread
     | DeleteStatus Int
     | DraftEvent DraftMsg
+    | FollowAccount Int
     | LoadAccount Int
     | MastodonEvent MastodonMsg
     | NoOp
@@ -71,6 +72,7 @@ type Msg
     | ScrollColumn String
     | ServerChange String
     | SubmitDraft
+    | UnfollowAccount Int
     | UrlChange Navigation.Location
     | UseGlobalTimeline Bool
     | UnreblogStatus Int

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -27,11 +27,13 @@ type ViewerMsg
 
 type MastodonMsg
     = AccessToken (Result Error AccessTokenResult)
+    | AccountFollowed (Result Error Account)
     | AccountFollowers (Result Error (List Account))
     | AccountFollowing (Result Error (List Account))
     | AccountReceived (Result Error Account)
     | AccountRelationships (Result Error (List Relationship))
     | AccountTimeline (Result Error (List Status))
+    | AccountUnfollowed (Result Error Account)
     | AppRegistered (Result Error AppRegistration)
     | ContextLoaded Status (Result Error Context)
     | CurrentUser (Result Error Account)

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -30,6 +30,7 @@ type MastodonMsg
     | AccountFollowers (Result Error (List Account))
     | AccountFollowing (Result Error (List Account))
     | AccountReceived (Result Error Account)
+    | AccountRelationships (Result Error (List Relationship))
     | AccountTimeline (Result Error (List Status))
     | AppRegistered (Result Error AppRegistration)
     | ContextLoaded Status (Result Error Context)
@@ -127,6 +128,7 @@ type alias Model =
     , accountTimeline : List Status
     , accountFollowers : List Account
     , accountFollowing : List Account
+    , accountRelationships : List Relationship
     , notifications : List NotificationAggregate
     , draft : Draft
     , errors : List String

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -31,6 +31,7 @@ type MastodonMsg
     | AccountFollowers (Result Error (List Account))
     | AccountFollowing (Result Error (List Account))
     | AccountReceived (Result Error Account)
+    | AccountRelationship (Result Error (List Relationship))
     | AccountRelationships (Result Error (List Relationship))
     | AccountTimeline (Result Error (List Status))
     | AccountUnfollowed (Result Error Relationship)
@@ -133,6 +134,7 @@ type alias Model =
     , accountFollowers : List Account
     , accountFollowing : List Account
     , accountRelationships : List Relationship
+    , accountRelationship : Maybe Relationship
     , notifications : List NotificationAggregate
     , draft : Draft
     , errors : List String

--- a/src/View.elm
+++ b/src/View.elm
@@ -18,6 +18,10 @@ type alias CurrentUser =
     Account
 
 
+type alias CurrentUserRelation =
+    Maybe Relationship
+
+
 visibilities : Dict.Dict String String
 visibilities =
     Dict.fromList
@@ -206,7 +210,7 @@ statusView context ({ account, content, media_attachments, reblog, mentions } as
                     ]
 
 
-followButton : CurrentUser -> Maybe Relationship -> Account -> Html Msg
+followButton : CurrentUser -> CurrentUserRelation -> Account -> Html Msg
 followButton currentUser relationship account =
     if Mastodon.Helper.sameAccount account currentUser then
         text ""
@@ -279,7 +283,7 @@ accountCounterLink label count tagger account =
         ]
 
 
-accountView : CurrentUser -> Account -> Maybe Relationship -> Html Msg -> Html Msg
+accountView : CurrentUser -> Account -> CurrentUserRelation -> Html Msg -> Html Msg
 accountView currentUser account relationship panelContent =
     let
         { statuses_count, following_count, followers_count } =
@@ -312,7 +316,7 @@ accountView currentUser account relationship panelContent =
             ]
 
 
-accountTimelineView : CurrentUser -> List Status -> Maybe Relationship -> Account -> Html Msg
+accountTimelineView : CurrentUser -> List Status -> CurrentUserRelation -> Account -> Html Msg
 accountTimelineView currentUser statuses relationship account =
     accountView currentUser account relationship <|
         ul [ class "list-group" ] <|
@@ -324,7 +328,13 @@ accountTimelineView currentUser statuses relationship account =
                 statuses
 
 
-accountFollowView : CurrentUser -> List Account -> List Relationship -> Maybe Relationship -> Account -> Html Msg
+accountFollowView :
+    CurrentUser
+    -> List Account
+    -> List Relationship
+    -> CurrentUserRelation
+    -> Account
+    -> Html Msg
 accountFollowView currentUser accounts relationships relationship account =
     accountView currentUser account relationship <|
         ul [ class "list-group" ] <|

--- a/src/View.elm
+++ b/src/View.elm
@@ -205,11 +205,15 @@ statusView context ({ account, content, media_attachments, reblog, mentions } as
 followView : Maybe Relationship -> Account -> Html Msg
 followView relationship account =
     let
-        ( follower, following, iconName, tooltip ) =
+        ( follower, following, btnClasses, iconName, tooltip ) =
             case relationship of
                 Just relationship ->
                     ( relationship.followed_by
                     , relationship.following
+                    , if relationship.following then
+                        "btn btn-default btn-primary"
+                      else
+                        "btn btn-default"
                     , if relationship.following then
                         "eye-close"
                       else
@@ -221,7 +225,7 @@ followView relationship account =
                     )
 
                 Nothing ->
-                    ( False, False, "", "" )
+                    ( False, False, "btn btn-default btn-disabled", "eye-open", "" )
     in
         div [ class "follow-entry" ]
             [ accountAvatarLink account
@@ -245,7 +249,7 @@ followView relationship account =
                 , br [] []
                 , text <| "@" ++ account.acct
                 ]
-            , button [ class "btn btn-default", title tooltip ]
+            , button [ class btnClasses, title tooltip ]
                 [ icon iconName ]
             ]
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -216,31 +216,28 @@ followButton currentUser relationship account =
         text ""
     else
         let
-            ( follower, following, followEvent, btnClasses, iconName, tooltip ) =
+            ( followEvent, btnClasses, iconName, tooltip ) =
                 case relationship of
-                    Just relationship ->
-                        ( relationship.followed_by
-                        , relationship.following
-                        , if relationship.following then
-                            UnfollowAccount account.id
-                          else
-                            FollowAccount account.id
-                        , if relationship.following then
-                            "btn btn-default btn-primary"
-                          else
-                            "btn btn-default"
-                        , if relationship.following then
-                            "eye-close"
-                          else
-                            "eye-open"
-                        , if relationship.following then
-                            "Unfollow"
-                          else
-                            "Follow"
+                    Nothing ->
+                        ( NoOp
+                        , "btn btn-default btn-disabled"
+                        , "question-sign"
+                        , "Unknown relationship"
                         )
 
-                    Nothing ->
-                        ( False, False, NoOp, "btn btn-default btn-disabled", "eye-open", "" )
+                    Just relationship ->
+                        if relationship.following then
+                            ( UnfollowAccount account.id
+                            , "btn btn-default btn-primary"
+                            , "eye-close"
+                            , "Unfollow"
+                            )
+                        else
+                            ( FollowAccount account.id
+                            , "btn btn-default"
+                            , "eye-open"
+                            , "Follow"
+                            )
         in
             button [ class btnClasses, title tooltip, onClick followEvent ]
                 [ icon iconName ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -202,8 +202,8 @@ statusView context ({ account, content, media_attachments, reblog, mentions } as
                     ]
 
 
-followView : Maybe Relationship -> Account -> Html Msg
-followView relationship account =
+followView : Account -> Maybe Relationship -> Account -> Html Msg
+followView currentUser relationship account =
     let
         ( follower, following, btnClasses, iconName, tooltip ) =
             case relationship of
@@ -249,8 +249,11 @@ followView relationship account =
                 , br [] []
                 , text <| "@" ++ account.acct
                 ]
-            , button [ class btnClasses, title tooltip ]
-                [ icon iconName ]
+            , if Mastodon.Helper.sameAccount account currentUser then
+                text ""
+              else
+                button [ class btnClasses, title tooltip ]
+                    [ icon iconName ]
             ]
 
 
@@ -311,14 +314,15 @@ accountTimelineView label statuses account =
                 statuses
 
 
-accountFollowView : String -> List Account -> List Relationship -> Account -> Html Msg
-accountFollowView label accounts relationships account =
+accountFollowView : String -> Account -> List Account -> List Relationship -> Account -> Html Msg
+accountFollowView label currentUser accounts relationships account =
     accountView label "user" account <|
         ul [ class "list-group" ] <|
             List.map
                 (\account ->
                     li [ class "list-group-item status" ]
                         [ followView
+                            currentUser
                             (find (\r -> r.id == account.id) relationships)
                             account
                         ]
@@ -739,6 +743,7 @@ homepageView model =
                     AccountFollowersView account followers ->
                         accountFollowView
                             "Account followers"
+                            currentUser
                             model.accountFollowers
                             model.accountRelationships
                             account
@@ -746,6 +751,7 @@ homepageView model =
                     AccountFollowingView account following ->
                         accountFollowView
                             "Account following"
+                            currentUser
                             model.accountFollowing
                             model.accountRelationships
                             account

--- a/src/View.elm
+++ b/src/View.elm
@@ -205,11 +205,15 @@ statusView context ({ account, content, media_attachments, reblog, mentions } as
 followView : Account -> Maybe Relationship -> Account -> Html Msg
 followView currentUser relationship account =
     let
-        ( follower, following, btnClasses, iconName, tooltip ) =
+        ( follower, following, followEvent, btnClasses, iconName, tooltip ) =
             case relationship of
                 Just relationship ->
                     ( relationship.followed_by
                     , relationship.following
+                    , if relationship.following then
+                        UnfollowAccount account.id
+                      else
+                        FollowAccount account.id
                     , if relationship.following then
                         "btn btn-default btn-primary"
                       else
@@ -225,7 +229,7 @@ followView currentUser relationship account =
                     )
 
                 Nothing ->
-                    ( False, False, "btn btn-default btn-disabled", "eye-open", "" )
+                    ( False, False, NoOp, "btn btn-default btn-disabled", "eye-open", "" )
     in
         div [ class "follow-entry" ]
             [ accountAvatarLink account
@@ -252,7 +256,7 @@ followView currentUser relationship account =
             , if Mastodon.Helper.sameAccount account currentUser then
                 text ""
               else
-                button [ class btnClasses, title tooltip ]
+                button [ class btnClasses, title tooltip, onClick followEvent ]
                     [ icon iconName ]
             ]
 


### PR DESCRIPTION
This patch adds support for following & unfollowing accounts from the account view and its followers/following sub views.