### PR TITLE
Fix #118: Render a draft char counter.

### DIFF
--- a/src/Model.elm
+++ b/src/Model.elm
@@ -221,8 +221,7 @@ updateDraft draftMsg currentUser model =
                 { model | draft = { draft | sensitive = sensitive } } ! []
 
             UpdateSpoiler spoilerText ->
-                { model | draft = { draft | spoilerText = Just spoilerText } }
-                    ! []
+                { model | draft = { draft | spoilerText = Just spoilerText } } ! []
 
             UpdateVisibility visibility ->
                 { model | draft = { draft | visibility = visibility } } ! []

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -35,6 +35,8 @@ defaultDraft =
     , spoilerText = Nothing
     , sensitive = False
     , visibility = "public"
+    , statusLength = 0
+    , length = 0
     , autoState = Autocomplete.empty
     , autoAtPosition = Nothing
     , autoQuery = ""
@@ -220,7 +222,14 @@ updateDraft draftMsg currentUser model =
                 { model | draft = { draft | sensitive = sensitive } } ! []
 
             UpdateSpoiler spoilerText ->
-                { model | draft = { draft | spoilerText = Just spoilerText } } ! []
+                { model
+                    | draft =
+                        { draft
+                            | spoilerText = Just spoilerText
+                            , length = draft.statusLength + (String.length spoilerText)
+                        }
+                }
+                    ! []
 
             UpdateVisibility visibility ->
                 { model | draft = { draft | visibility = visibility } } ! []
@@ -247,6 +256,24 @@ updateDraft draftMsg currentUser model =
                         ! [ Command.focusId "status"
                           , Command.updateDomStatus newStatus
                           ]
+
+            UpdateStatusLength statusLength ->
+                let
+                    spoilerLength =
+                        case draft.spoilerText of
+                            Nothing ->
+                                0
+
+                            Just text ->
+                                text |> String.length
+
+                    newDraft =
+                        { draft
+                            | length = spoilerLength + statusLength
+                            , statusLength = statusLength
+                        }
+                in
+                    { model | draft = newDraft } ! []
 
             UpdateInputInformation { status, selectionStart } ->
                 let

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -36,7 +36,6 @@ defaultDraft =
     , sensitive = False
     , visibility = "public"
     , statusLength = 0
-    , length = 0
     , autoState = Autocomplete.empty
     , autoAtPosition = Nothing
     , autoQuery = ""
@@ -222,13 +221,7 @@ updateDraft draftMsg currentUser model =
                 { model | draft = { draft | sensitive = sensitive } } ! []
 
             UpdateSpoiler spoilerText ->
-                { model
-                    | draft =
-                        { draft
-                            | spoilerText = Just spoilerText
-                            , length = draft.statusLength + (String.length spoilerText)
-                        }
-                }
+                { model | draft = { draft | spoilerText = Just spoilerText } }
                     ! []
 
             UpdateVisibility visibility ->
@@ -257,24 +250,6 @@ updateDraft draftMsg currentUser model =
                           , Command.updateDomStatus newStatus
                           ]
 
-            UpdateStatusLength statusLength ->
-                let
-                    spoilerLength =
-                        case draft.spoilerText of
-                            Nothing ->
-                                0
-
-                            Just text ->
-                                text |> String.length
-
-                    newDraft =
-                        { draft
-                            | length = spoilerLength + statusLength
-                            , statusLength = statusLength
-                        }
-                in
-                    { model | draft = newDraft } ! []
-
             UpdateInputInformation { status, selectionStart } ->
                 let
                     stringToPos =
@@ -302,6 +277,7 @@ updateDraft draftMsg currentUser model =
                     newDraft =
                         { draft
                             | status = status
+                            , statusLength = String.length status
                             , autoCursorPosition = selectionStart
                             , autoAtPosition = atPosition
                             , autoQuery = query

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -15,7 +15,6 @@ type DraftMsg
     = ClearDraft
     | UpdateSensitive Bool
     | UpdateSpoiler String
-    | UpdateStatusLength Int
     | UpdateVisibility String
     | UpdateReplyTo Status
     | SelectAccount String
@@ -116,7 +115,6 @@ type alias Draft =
     , sensitive : Bool
     , visibility : String
     , statusLength : Int
-    , length : Int
 
     -- Autocomplete values
     , autoState : Autocomplete.State

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -15,6 +15,7 @@ type DraftMsg
     = ClearDraft
     | UpdateSensitive Bool
     | UpdateSpoiler String
+    | UpdateStatusLength Int
     | UpdateVisibility String
     | UpdateReplyTo Status
     | SelectAccount String
@@ -114,6 +115,8 @@ type alias Draft =
     , spoilerText : Maybe String
     , sensitive : Bool
     , visibility : String
+    , statusLength : Int
+    , length : Int
 
     -- Autocomplete values
     , autoState : Autocomplete.State

--- a/src/View/Common.elm
+++ b/src/View/Common.elm
@@ -12,7 +12,6 @@ import Html.Attributes exposing (..)
 import Mastodon.Model exposing (..)
 import Types exposing (..)
 import View.Events exposing (..)
-import View.Formatter exposing (formatContent)
 
 
 accountLink : Account -> Html Msg

--- a/src/View/Draft.elm
+++ b/src/View/Draft.elm
@@ -215,6 +215,7 @@ draftView ({ draft, currentUser } as model) =
                                 , onClickInformation <| DraftEvent << UpdateInputInformation
                                 , property "defaultValue" (Encode.string draft.status)
                                 , onWithOptions "keydown" options dec
+                                , onInput <| DraftEvent << UpdateStatusLength << String.length
                                 ]
                                 []
                         , autoMenu
@@ -250,6 +251,11 @@ draftView ({ draft, currentUser } as model) =
                             , onClick (DraftEvent ClearDraft)
                             ]
                             [ text "Clear" ]
+                        , button
+                            [ type_ "button"
+                            , class "btn btn-default active"
+                            ]
+                            [ text <| toString draft.length ]
                         , button
                             [ type_ "submit"
                             , class "btn btn-primary"

--- a/src/View/Draft.elm
+++ b/src/View/Draft.elm
@@ -113,9 +113,6 @@ draftReplyToView draft =
 draftView : Model -> Html Msg
 draftView ({ draft, currentUser } as model) =
     let
-        hasSpoiler =
-            draft.spoilerText /= Nothing
-
         visibilityOptionView ( visibility, description ) =
             option [ value visibility ]
                 [ text <| visibility ++ ": " ++ description ]
@@ -125,6 +122,14 @@ draftView ({ draft, currentUser } as model) =
                 viewAutocompleteMenu model.draft
             else
                 text ""
+
+        ( hasSpoiler, charCount ) =
+            case draft.spoilerText of
+                Just spoilerText ->
+                    ( True, (String.length spoilerText) + draft.statusLength )
+
+                Nothing ->
+                    ( False, draft.statusLength )
     in
         div [ class "panel panel-default" ]
             [ div [ class "panel-heading" ]
@@ -215,7 +220,6 @@ draftView ({ draft, currentUser } as model) =
                                 , onClickInformation <| DraftEvent << UpdateInputInformation
                                 , property "defaultValue" (Encode.string draft.status)
                                 , onWithOptions "keydown" options dec
-                                , onInput <| DraftEvent << UpdateStatusLength << String.length
                                 ]
                                 []
                         , autoMenu
@@ -255,7 +259,7 @@ draftView ({ draft, currentUser } as model) =
                             [ type_ "button"
                             , class "btn btn-default active"
                             ]
-                            [ text <| toString draft.length ]
+                            [ text <| toString charCount ]
                         , button
                             [ type_ "submit"
                             , class "btn btn-primary"

--- a/src/View/Draft.elm
+++ b/src/View/Draft.elm
@@ -130,6 +130,9 @@ draftView ({ draft, currentUser } as model) =
 
                 Nothing ->
                     ( False, draft.statusLength )
+
+        limitExceeded =
+            charCount > 500
     in
         div [ class "panel panel-default" ]
             [ div [ class "panel-heading" ]
@@ -257,12 +260,17 @@ draftView ({ draft, currentUser } as model) =
                             [ text "Clear" ]
                         , button
                             [ type_ "button"
-                            , class "btn btn-default active"
+                            , class <|
+                                if limitExceeded then
+                                    "btn btn-danger active"
+                                else
+                                    "btn btn-default active"
                             ]
                             [ text <| toString charCount ]
                         , button
                             [ type_ "submit"
                             , class "btn btn-primary"
+                            , disabled limitExceeded
                             ]
                             [ text "Toot!" ]
                         ]


### PR DESCRIPTION
This tries to add a char counter for a draft, adding the spoiler text length if any and the status one. The counter works, but as the `onInput` event I've put on the textarea seems to prevent to store the status text properly, when submitting a toot the status content is empty, and the server answers with an error.

@vjousse do you have an idea what's going on here? 