### PR TITLE
Fix #121: Refactor Mastodon.Http

### DIFF
--- a/src/Mastodon/ApiUrl.elm
+++ b/src/Mastodon/ApiUrl.elm
@@ -32,19 +32,19 @@ type alias Server =
     String
 
 
-apps : Server -> String
-apps server =
-    server ++ "/api/v1/apps"
+apps : String
+apps =
+    "/api/v1/apps"
 
 
-oauthAuthorize : Server -> String
-oauthAuthorize server =
-    server ++ "/oauth/authorize"
+oauthAuthorize : String
+oauthAuthorize =
+    "/oauth/authorize"
 
 
-oauthToken : Server -> String
-oauthToken server =
-    server ++ "/oauth/token"
+oauthToken : String
+oauthToken =
+    "/oauth/token"
 
 
 accounts : String
@@ -57,33 +57,24 @@ account id =
     accounts ++ (toString id)
 
 
-follow : Server -> Int -> String
-follow server id =
-    server ++ accounts ++ (toString id) ++ "/follow"
+follow : Int -> String
+follow id =
+    accounts ++ (toString id) ++ "/follow"
 
 
-unfollow : Server -> Int -> String
-unfollow server id =
-    server ++ accounts ++ (toString id) ++ "/unfollow"
+unfollow : Int -> String
+unfollow id =
+    accounts ++ (toString id) ++ "/unfollow"
 
 
-userAccount : Server -> String
-userAccount server =
-    server ++ accounts ++ "verify_credentials"
+userAccount : String
+userAccount =
+    accounts ++ "verify_credentials"
 
 
-searchAccount : Server -> String -> Int -> Bool -> String
-searchAccount server query limit resolve =
-    encodeUrl (server ++ accounts ++ "search")
-        [ ( "q", query )
-        , ( "limit", toString limit )
-        , ( "resolve"
-          , if resolve then
-                "true"
-            else
-                "false"
-          )
-        ]
+searchAccount : String
+searchAccount =
+    accounts ++ "search"
 
 
 relationships : List Int -> String
@@ -131,41 +122,41 @@ notifications =
     "/api/v1/notifications"
 
 
-statuses : Server -> String
-statuses server =
-    server ++ "/api/v1/statuses"
+statuses : String
+statuses =
+    "/api/v1/statuses"
 
 
-context : Server -> Int -> String
-context server id =
-    statuses server ++ "/" ++ (toString id) ++ "/context"
+context : Int -> String
+context id =
+    statuses ++ "/" ++ (toString id) ++ "/context"
 
 
-reblog : Server -> Int -> String
-reblog server id =
-    statuses server ++ "/" ++ (toString id) ++ "/reblog"
+reblog : Int -> String
+reblog id =
+    statuses ++ "/" ++ (toString id) ++ "/reblog"
 
 
-status : Server -> Int -> String
-status server id =
-    statuses server ++ "/" ++ (toString id)
+status : Int -> String
+status id =
+    statuses ++ "/" ++ (toString id)
 
 
-unreblog : Server -> Int -> String
-unreblog server id =
-    statuses server ++ "/" ++ (toString id) ++ "/unreblog"
+unreblog : Int -> String
+unreblog id =
+    statuses ++ "/" ++ (toString id) ++ "/unreblog"
 
 
-favourite : Server -> Int -> String
-favourite server id =
-    statuses server ++ "/" ++ (toString id) ++ "/favourite"
+favourite : Int -> String
+favourite id =
+    statuses ++ "/" ++ (toString id) ++ "/favourite"
 
 
-unfavourite : Server -> Int -> String
-unfavourite server id =
-    statuses server ++ "/" ++ (toString id) ++ "/unfavourite"
+unfavourite : Int -> String
+unfavourite id =
+    statuses ++ "/" ++ (toString id) ++ "/unfavourite"
 
 
-streaming : Server -> String
-streaming server =
-    server ++ "/api/v1/streaming/"
+streaming : String
+streaming =
+    "/api/v1/streaming/"

--- a/src/Mastodon/ApiUrl.elm
+++ b/src/Mastodon/ApiUrl.elm
@@ -26,13 +26,14 @@ module Mastodon.ApiUrl
         )
 
 
-type alias Server =
-    String
+apiPrefix : String
+apiPrefix =
+    "/api/v1/"
 
 
 apps : String
 apps =
-    "/api/v1/apps"
+    apiPrefix ++ "/apps"
 
 
 oauthAuthorize : String
@@ -47,7 +48,7 @@ oauthToken =
 
 accounts : String
 accounts =
-    "/api/v1/accounts/"
+    apiPrefix ++ "/accounts/"
 
 
 account : Int -> String
@@ -92,12 +93,12 @@ following id =
 
 homeTimeline : String
 homeTimeline =
-    "/api/v1/timelines/home"
+    apiPrefix ++ "/timelines/home"
 
 
 publicTimeline : String
 publicTimeline =
-    "/api/v1/timelines/public"
+    apiPrefix ++ "/timelines/public"
 
 
 accountTimeline : Int -> String
@@ -107,12 +108,12 @@ accountTimeline id =
 
 notifications : String
 notifications =
-    "/api/v1/notifications"
+    apiPrefix ++ "/notifications"
 
 
 statuses : String
 statuses =
-    "/api/v1/statuses"
+    apiPrefix ++ "/statuses"
 
 
 context : Int -> String
@@ -147,4 +148,4 @@ unfavourite id =
 
 streaming : String
 streaming =
-    "/api/v1/streaming/"
+    apiPrefix ++ "/streaming/"

--- a/src/Mastodon/ApiUrl.elm
+++ b/src/Mastodon/ApiUrl.elm
@@ -25,8 +25,6 @@ module Mastodon.ApiUrl
         , searchAccount
         )
 
-import Mastodon.Encoder exposing (encodeUrl)
-
 
 type alias Server =
     String
@@ -77,10 +75,9 @@ searchAccount =
     accounts ++ "search"
 
 
-relationships : List Int -> String
-relationships ids =
-    encodeUrl (accounts ++ "relationships") <|
-        List.map (\id -> ( "id[]", toString id )) ids
+relationships : String
+relationships =
+    accounts ++ "relationships"
 
 
 followers : Int -> String
@@ -98,18 +95,9 @@ homeTimeline =
     "/api/v1/timelines/home"
 
 
-publicTimeline : Maybe String -> String
-publicTimeline local =
-    let
-        isLocal =
-            case local of
-                Just local ->
-                    "?local=true"
-
-                Nothing ->
-                    ""
-    in
-        "/api/v1/timelines/public" ++ isLocal
+publicTimeline : String
+publicTimeline =
+    "/api/v1/timelines/public"
 
 
 accountTimeline : Int -> String

--- a/src/Mastodon/Http.elm
+++ b/src/Mastodon/Http.elm
@@ -140,20 +140,19 @@ fetchUserTimeline client =
 
 fetchRelationships : Client -> List Int -> Request (List Relationship)
 fetchRelationships client ids =
-    -- TODO: use withQueryParams
-    fetch client GET (ApiUrl.relationships ids) <| Decode.list relationshipDecoder
+    fetch client GET ApiUrl.relationships (Decode.list relationshipDecoder)
+        |> Build.withQueryParams (List.map (\id -> ( "id[]", toString id )) ids)
 
 
 fetchLocalTimeline : Client -> Request (List Status)
 fetchLocalTimeline client =
-    -- TODO: use withQueryParams
-    fetch client GET (ApiUrl.publicTimeline (Just "public")) <| Decode.list statusDecoder
+    fetch client GET ApiUrl.publicTimeline (Decode.list statusDecoder)
+        |> Build.withQueryParams [ ( "local", "true" ) ]
 
 
 fetchGlobalTimeline : Client -> Request (List Status)
 fetchGlobalTimeline client =
-    -- TODO: use withQueryParams
-    fetch client GET (ApiUrl.publicTimeline (Nothing)) <| Decode.list statusDecoder
+    fetch client GET ApiUrl.publicTimeline <| Decode.list statusDecoder
 
 
 fetchAccountTimeline : Client -> Int -> Request (List Status)

--- a/src/Mastodon/Http.elm
+++ b/src/Mastodon/Http.elm
@@ -36,6 +36,12 @@ import Mastodon.Encoder exposing (..)
 import Mastodon.Model exposing (..)
 
 
+type Method
+    = GET
+    | POST
+    | DELETE
+
+
 type alias Request a =
     Build.RequestBuilder a
 
@@ -74,16 +80,10 @@ toResponse result =
     Result.mapError extractError result
 
 
-type Method
-    = GET
-    | POST
-    | DELETE
-
-
-fetch : Client -> Method -> String -> Decode.Decoder a -> Request a
-fetch client method endpoint decoder =
+request : String -> Method -> String -> Decode.Decoder a -> Request a
+request server method endpoint decoder =
     let
-        request =
+        httpMethod =
             case method of
                 GET ->
                     Build.get
@@ -94,22 +94,25 @@ fetch client method endpoint decoder =
                 DELETE ->
                     Build.delete
     in
-        request (client.server ++ endpoint)
-            |> Build.withHeader "Authorization" ("Bearer " ++ client.token)
+        httpMethod (server ++ endpoint)
             |> Build.withExpect (Http.expectJson decoder)
+
+
+authRequest : Client -> Method -> String -> Decode.Decoder a -> Request a
+authRequest client method endpoint decoder =
+    request client.server method endpoint decoder
+        |> Build.withHeader "Authorization" ("Bearer " ++ client.token)
 
 
 register : String -> String -> String -> String -> String -> Request AppRegistration
 register server clientName redirectUri scope website =
-    Build.post (server ++ ApiUrl.apps)
-        |> Build.withExpect (Http.expectJson (appRegistrationDecoder server scope))
+    request server POST ApiUrl.apps (appRegistrationDecoder server scope)
         |> Build.withJsonBody (appRegistrationEncoder clientName redirectUri scope website)
 
 
 getAccessToken : AppRegistration -> String -> Request AccessTokenResult
 getAccessToken registration authCode =
-    Build.post (registration.server ++ ApiUrl.oauthToken)
-        |> Build.withExpect (Http.expectJson (accessTokenDecoder registration))
+    request registration.server POST ApiUrl.oauthToken (accessTokenDecoder registration)
         |> Build.withJsonBody (authorizationCodeEncoder registration authCode)
 
 
@@ -130,54 +133,54 @@ send tagger builder =
 
 fetchAccount : Client -> Int -> Request Account
 fetchAccount client accountId =
-    fetch client GET (ApiUrl.account accountId) accountDecoder
+    authRequest client GET (ApiUrl.account accountId) accountDecoder
 
 
 fetchUserTimeline : Client -> Request (List Status)
 fetchUserTimeline client =
-    fetch client GET ApiUrl.homeTimeline <| Decode.list statusDecoder
+    authRequest client GET ApiUrl.homeTimeline <| Decode.list statusDecoder
 
 
 fetchRelationships : Client -> List Int -> Request (List Relationship)
 fetchRelationships client ids =
-    fetch client GET ApiUrl.relationships (Decode.list relationshipDecoder)
+    authRequest client GET ApiUrl.relationships (Decode.list relationshipDecoder)
         |> Build.withQueryParams (List.map (\id -> ( "id[]", toString id )) ids)
 
 
 fetchLocalTimeline : Client -> Request (List Status)
 fetchLocalTimeline client =
-    fetch client GET ApiUrl.publicTimeline (Decode.list statusDecoder)
+    authRequest client GET ApiUrl.publicTimeline (Decode.list statusDecoder)
         |> Build.withQueryParams [ ( "local", "true" ) ]
 
 
 fetchGlobalTimeline : Client -> Request (List Status)
 fetchGlobalTimeline client =
-    fetch client GET ApiUrl.publicTimeline <| Decode.list statusDecoder
+    authRequest client GET ApiUrl.publicTimeline <| Decode.list statusDecoder
 
 
 fetchAccountTimeline : Client -> Int -> Request (List Status)
 fetchAccountTimeline client id =
-    fetch client GET (ApiUrl.accountTimeline id) <| Decode.list statusDecoder
+    authRequest client GET (ApiUrl.accountTimeline id) <| Decode.list statusDecoder
 
 
 fetchNotifications : Client -> Request (List Notification)
 fetchNotifications client =
-    fetch client GET (ApiUrl.notifications) <| Decode.list notificationDecoder
+    authRequest client GET (ApiUrl.notifications) <| Decode.list notificationDecoder
 
 
 fetchAccountFollowers : Client -> Int -> Request (List Account)
 fetchAccountFollowers client accountId =
-    fetch client GET (ApiUrl.followers accountId) <| Decode.list accountDecoder
+    authRequest client GET (ApiUrl.followers accountId) <| Decode.list accountDecoder
 
 
 fetchAccountFollowing : Client -> Int -> Request (List Account)
 fetchAccountFollowing client accountId =
-    fetch client GET (ApiUrl.following accountId) <| Decode.list accountDecoder
+    authRequest client GET (ApiUrl.following accountId) <| Decode.list accountDecoder
 
 
 searchAccounts : Client -> String -> Int -> Bool -> Request (List Account)
 searchAccounts client query limit resolve =
-    fetch client GET ApiUrl.searchAccount (Decode.list accountDecoder)
+    authRequest client GET ApiUrl.searchAccount (Decode.list accountDecoder)
         |> Build.withQueryParams
             [ ( "q", query )
             , ( "limit", toString limit )
@@ -192,50 +195,50 @@ searchAccounts client query limit resolve =
 
 userAccount : Client -> Request Account
 userAccount client =
-    fetch client GET ApiUrl.userAccount accountDecoder
+    authRequest client GET ApiUrl.userAccount accountDecoder
 
 
 postStatus : Client -> StatusRequestBody -> Request Status
 postStatus client statusRequestBody =
-    fetch client POST ApiUrl.statuses statusDecoder
+    authRequest client POST ApiUrl.statuses statusDecoder
         |> Build.withJsonBody (statusRequestBodyEncoder statusRequestBody)
 
 
 deleteStatus : Client -> Int -> Request Int
 deleteStatus client id =
-    fetch client DELETE (ApiUrl.status id) <| Decode.succeed id
+    authRequest client DELETE (ApiUrl.status id) <| Decode.succeed id
 
 
 context : Client -> Int -> Request Context
 context client id =
-    fetch client GET (ApiUrl.context id) contextDecoder
+    authRequest client GET (ApiUrl.context id) contextDecoder
 
 
 reblog : Client -> Int -> Request Status
 reblog client id =
-    fetch client POST (ApiUrl.reblog id) statusDecoder
+    authRequest client POST (ApiUrl.reblog id) statusDecoder
 
 
 unreblog : Client -> Int -> Request Status
 unreblog client id =
-    fetch client POST (ApiUrl.unreblog id) statusDecoder
+    authRequest client POST (ApiUrl.unreblog id) statusDecoder
 
 
 favourite : Client -> Int -> Request Status
 favourite client id =
-    fetch client POST (ApiUrl.favourite id) statusDecoder
+    authRequest client POST (ApiUrl.favourite id) statusDecoder
 
 
 unfavourite : Client -> Int -> Request Status
 unfavourite client id =
-    fetch client POST (ApiUrl.unfavourite id) statusDecoder
+    authRequest client POST (ApiUrl.unfavourite id) statusDecoder
 
 
 follow : Client -> Int -> Request Relationship
 follow client id =
-    fetch client POST (ApiUrl.follow id) relationshipDecoder
+    authRequest client POST (ApiUrl.follow id) relationshipDecoder
 
 
 unfollow : Client -> Int -> Request Relationship
 unfollow client id =
-    fetch client POST (ApiUrl.unfollow id) relationshipDecoder
+    authRequest client POST (ApiUrl.unfollow id) relationshipDecoder

--- a/src/Mastodon/WebSocket.elm
+++ b/src/Mastodon/WebSocket.elm
@@ -54,7 +54,7 @@ subscribeToWebSockets client streamType message =
 
         url =
             encodeUrl
-                (ApiUrl.streaming (replaceSlice "wss" 0 5 client.server))
+                (replaceSlice "wss" 0 5 <| client.server ++ ApiUrl.streaming)
                 [ ( "access_token", client.token )
                 , ( "stream", type_ )
                 ]


### PR DESCRIPTION
- [x] Some ApiUrl endpoints fns shouldn't take a server parameters.
- [x] `fetch` should accept a parameter to specify the HTTP method to use, and every request fns should use that.
- [x] Query string parameters should be dealt with using `HttpBuilder.withParams`