### PR TITLE
Fix #133: Show status visibility.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -348,6 +348,15 @@ body {
   color: #555;
 }
 
+.btn-vis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.btn-vis > span {
+  margin-left: 6px;
+}
+
 /* Status text content rules */
 
 .attachment, .hashtag, .ellipsis {

--- a/src/View/Draft.elm
+++ b/src/View/Draft.elm
@@ -20,12 +20,12 @@ type alias CurrentUser =
     Account
 
 
-visibilities : List ( String, String, String )
+visibilities : List ( String, String, String, String )
 visibilities =
-    [ ( "unlisted", "do not show in public timelines", "eye-close" )
-    , ( "private", "post to followers only", "user" )
-    , ( "direct", "post to mentioned users only", "lock" )
-    , ( "public", "post to public timelines", "globe" )
+    [ ( "direct", "Mentioned", "Visible to mentioned users only", "envelope" )
+    , ( "private", "Followers", "Visible to followers only", "lock" )
+    , ( "unlisted", "Unlisted", "Do not show in public timelines", "eye-close" )
+    , ( "public", "Public", "Visible in public timelines", "globe" )
     ]
 
 
@@ -113,20 +113,20 @@ visibilitySelector { visibility } =
     let
         btnClass v =
             if v == visibility then
-                "btn btn-sm btn-primary active"
+                "btn btn-sm btn-vis btn-primary active"
             else
-                "btn btn-sm btn-default"
+                "btn btn-sm btn-vis btn-default"
     in
         visibilities
             |> List.map
-                (\( v, t, i ) ->
+                (\( v, d, t, i ) ->
                     a
                         [ href ""
                         , class <| btnClass v
                         , onClickWithPreventAndStop <| DraftEvent (UpdateVisibility v)
                         , title t
                         ]
-                        [ Common.icon i, text " ", text v ]
+                        [ Common.icon i, span [] [ text d ] ]
                 )
             |> Common.justifiedButtonGroup "draft-visibilities"
 

--- a/src/View/Status.elm
+++ b/src/View/Status.elm
@@ -123,11 +123,18 @@ statusActionsView status currentUser =
                     DraftEvent (UpdateReplyTo status)
                 ]
                 [ Common.icon "share-alt" ]
-            , a
-                [ class reblogClasses
-                , onClickWithPreventAndStop reblogEvent
-                ]
-                [ Common.icon "fire", text (toString sourceStatus.reblogs_count) ]
+            , if status.visibility == "private" then
+                span [ class <| reblogClasses ++ " disabled" ]
+                    [ span [ title "Private" ] [ Common.icon "lock" ] ]
+              else if status.visibility == "direct" then
+                span [ class <| reblogClasses ++ " disabled" ]
+                    [ span [ title "Direct" ] [ Common.icon "envelope" ] ]
+              else
+                a
+                    [ class reblogClasses
+                    , onClickWithPreventAndStop reblogEvent
+                    ]
+                    [ Common.icon "fire", text (toString sourceStatus.reblogs_count) ]
             , a
                 [ class favClasses
                 , onClickWithPreventAndStop favEvent


### PR DESCRIPTION
Also revisits the way we expose visibility choices (and their hierarchy) in the draft form.

![](http://i.imgur.com/CW0AW01.png)

![](http://i.imgur.com/fxwovtr.png)