### PR TITLE
Color on hover on action buttons

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -247,12 +247,18 @@ li.load-more {
   box-shadow: none;
 }
 
+.actions > .btn:hover > .glyphicon-star,
 .actions .favourited {
   color: #d1ac0e;
 }
-
+.actions > .btn:hover > .glyphicon-fire,
 .actions .reblogged {
   color: #d56344;
+}
+
+.actions > .btn:hover > .glyphicon-share-alt,
+.actions > .btn-delete:hover {
+  color: #fff;
 }
 
 .btn-delete .glyphicon {


### PR DESCRIPTION
following https://github.com/n1k0/tooty/commit/c318be3aa20094870a6219ee65bf6f9f863bbcb8

As buttons don't have a distinctive class yet, color is only applied on icon for now
With `.reblog` and `.favourite`class on button, count could also be included à la Twitter.

![actions-hover](https://cloud.githubusercontent.com/assets/103008/25782382/53ad0aca-334a-11e7-9f52-7c46bc9e0eaa.gif)
