### PR TITLE
Remove body overflow

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,7 +1,6 @@
 body {
   font-family: Roboto, sans-serif;
   padding: 10px 0 0 0;
-  overflow: hidden;
 }
 
 /* Alert messages */


### PR DESCRIPTION
It enables vertical scrolling on mobile browsers.

I have not noticed any visual difference with and without the removed CSS declaration.

refs #79 