### PR TITLE
Fix #72: Add browser notifications.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,26 @@
         .then(response => response.text())
         .then(app.ports.uploadSuccess.send);
     });
+
+    function notify(data) {
+      const notif = new Notification(data.title, {
+        icon: data.icon,
+        body: data.body,
+      });
+      notif.onclick = () => location.hash = data.clickUrl;
+    }
+
+    app.ports.notify.subscribe(data => {
+      if (Notification.permission === "granted") {
+        notify(data);
+      } else if (Notification.permission !== "denied") {
+        Notification.requestPermission(permission => {
+          if (permission === "granted") {
+            notify(data);
+          }
+        });
+      }
+    });
     </script>
   </body>
 </html>

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -6,6 +6,7 @@ port module Ports
         , saveClients
         , setStatus
         , uploadMedia
+        , notify
         , uploadSuccess
         , uploadError
         )
@@ -29,6 +30,9 @@ port scrollIntoView : String -> Cmd msg
 
 
 port uploadMedia : { id : String, url : String, token : String } -> Cmd msg
+
+
+port notify : { title : String, icon : String, body : String, clickUrl : String } -> Cmd msg
 
 
 

--- a/src/Update/WebSocket.elm
+++ b/src/Update/WebSocket.elm
@@ -1,5 +1,6 @@
 module Update.WebSocket exposing (update)
 
+import Command
 import Mastodon.Decoder
 import Mastodon.Helper
 import Mastodon.Model exposing (..)
@@ -52,7 +53,8 @@ update msg model =
                                                 oldNotifications.entries
                                     }
                             in
-                                { model | notifications = newNotifications } ! []
+                                { model | notifications = newNotifications }
+                                    ! [ Command.notifyNotification notification ]
 
                         Err error ->
                             { model | errors = addErrorNotification error model } ! []

--- a/src/View/Formatter.elm
+++ b/src/View/Formatter.elm
@@ -1,10 +1,11 @@
-module View.Formatter exposing (formatContent)
+module View.Formatter exposing (formatContent, textContent)
 
 import Dict
 import Elmoji
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import HtmlParser
+import HtmlParser.Util as ParseUtil
 import Http
 import Mastodon.Model exposing (..)
 import String.Extra exposing (replace, rightOf)
@@ -20,6 +21,11 @@ formatContent content mentions =
         |> replace " :" "&#160;:"
         |> HtmlParser.parse
         |> toVirtualDom mentions
+
+
+textContent : String -> String
+textContent html =
+    html |> HtmlParser.parse |> ParseUtil.textContent
 
 
 {-| Converts nodes to virtual dom nodes.


### PR DESCRIPTION
This only enables browser notifications for the Mastodon user notifications feed. Requests permission on first call. We might want a dedicated UI for this, with more granular control on what kind of notifications we want. 