### PR TITLE
Fixes for `npm run deploy`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "copy-assets": "rimraf build && mkdir -p build/v2 && cp -r public/* build/v2",
     "debug": "elm-live src/Main.elm --warn --dir=public/ --port=3000 -- --output=public/app.js --debug",
     "debug:all": "./scripts/watch-live.sh",
-    "deploy": "npm run build && npm run optimize && gh-pages --add --dist build/",
+    "deploy": "npm run build && npm run optimize && gh-pages --add --dist build/v2",
     "optimize": "uglifyjs build/v2/app.js -c -m -o build/v2/app.js",
     "live": "elm-live src/Main.elm --port=3000 --dir=public/ -- --output=public/app.js",
     "live:style": "chokidar 'public/**/*.css' -c 'touch src/Main.elm'",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An alternative Web client for Mastodon.",
   "scripts": {
     "build": "npm run copy-assets && elm make src/Main.elm --optimize --output=build/v2/app.js",
-    "copy-assets": "rimraf build && mkdir -p build/v2 && cp -r public/* build/v2 && cp public/.nojekyll build/v2/.",
+    "copy-assets": "rimraf build && mkdir -p build/v2 && cp -r public/* build/v2 && touch build/v2/.nojekyll",
     "debug": "elm-live src/Main.elm --warn --dir=public/ --port=3000 -- --output=public/app.js --debug",
     "debug:all": "./scripts/watch-live.sh",
     "deploy": "npm run build && npm run optimize && gh-pages --dotfiles --dist build/v2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "copy-assets": "rimraf build && mkdir -p build/v2 && cp -r public/* build/v2",
     "debug": "elm-live src/Main.elm --warn --dir=public/ --port=3000 -- --output=public/app.js --debug",
     "debug:all": "./scripts/watch-live.sh",
-    "deploy": "npm run build && npm run optimize && gh-pages --add --dist build/v2",
+    "deploy": "npm run build && npm run optimize && gh-pages --dist build/v2",
     "optimize": "uglifyjs build/v2/app.js -c -m -o build/v2/app.js",
     "live": "elm-live src/Main.elm --port=3000 --dir=public/ -- --output=public/app.js",
     "live:style": "chokidar 'public/**/*.css' -c 'touch src/Main.elm'",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "copy-assets": "rimraf build && mkdir -p build/v2 && cp -r public/* build/v2",
     "debug": "elm-live src/Main.elm --warn --dir=public/ --port=3000 -- --output=public/app.js --debug",
     "debug:all": "./scripts/watch-live.sh",
-    "deploy": "npm run build && npm run optimize && gh-pages --dist build/v2",
+    "deploy": "npm run build && npm run optimize && gh-pages --dotfiles --dist build/v2",
     "optimize": "uglifyjs build/v2/app.js -c -m -o build/v2/app.js",
     "live": "elm-live src/Main.elm --port=3000 --dir=public/ -- --output=public/app.js",
     "live:style": "chokidar 'public/**/*.css' -c 'touch src/Main.elm'",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An alternative Web client for Mastodon.",
   "scripts": {
     "build": "npm run copy-assets && elm make src/Main.elm --optimize --output=build/v2/app.js",
-    "copy-assets": "rimraf build && mkdir -p build/v2 && cp -r public/* build/v2",
+    "copy-assets": "rimraf build && mkdir -p build/v2 && cp -r public/* build/v2 && cp public/.nojekyll build/v2/.",
     "debug": "elm-live src/Main.elm --warn --dir=public/ --port=3000 -- --output=public/app.js --debug",
     "debug:all": "./scripts/watch-live.sh",
     "deploy": "npm run build && npm run optimize && gh-pages --dotfiles --dist build/v2",


### PR DESCRIPTION
Hiya,

In my attempt to fix a bug, I discovered that the deploy steps implemented in `npm run deploy` were in a confused state. 

## Steps to reproduce:

In a fresh fork of tooty, run `npm run deploy`.  You'll see the readme.md as index.html, which is confusing because the documentation says you should see the Elm app.  It was actually deployed to `/tooty/v2`.

The readme.md was converted to index.html by Github now running jekyll build on all projects - even though this isn't a jekyll project.

Therefore, I made some changes: 

## 1. Deploy to repo root directory instead of /tooty/v2

The Readme.md says the deployed URL will be:

> https://[your-github-username].github.io/tooty/

but the actual deploy was going to /tooty/v2. This is particularly confusing because Github was converting `readme.md` to `index.html` when trying to build the project with Jekyll.

**Recommendation**: Deleting your `gh-pages` [branch](https://github.com/n1k0/tooty/tree/gh-pages) one time will remove the confusing state of your branch (with content in both /(root) and /v2)

**Actions Taken**: Added `/v2` to the `gh-pages` dist parameter.

## 2. `gh-pages` branch was mixing `deploy/v2` and `/(root)`

gh-pages's `--add` flag moves the content from `--dist` to the root of the project, but we actually should just replace the content at root with `deploy/v2`'s content.   Removing the `--add` flag stops the content from merging together.

**Actions Taken**: Removed `--add` from `gh-pages`

## 3. Github Pages defaults to doing a jekyll build

Per the [Github Documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) regarding deploying github pages:

> Most external CI workflows "deploy" to GitHub Pages by committing the build output to the gh-pages branch of the repository, and typically include a .nojekyll file. When this happens, the GitHub Actions workflow will detect the state that the branch does not need a build step, and will execute only the steps necessary to deploy the site to GitHub Pages servers.

**Actions Taken**: Added a `touch build/v2/.nojekyll` to the `copy-assets` npm command.


### 4. The project description links to v2
> <img width="200" alt="image" src="https://github.com/user-attachments/assets/c33c86cc-c99f-44a4-9b66-c3eb21607b3c" />

**Recommendation**: After merging, remove the v2 from the project description on github.